### PR TITLE
refactor: Refactor sftp module into separate ssh/sftp modules

### DIFF
--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1,7 +1,6 @@
 use anyhow::Context;
 use firewall::allow_port_through_firewall;
 use firewall::disable_firewalls;
-use sftp::SFTP_LISTEN_PORT;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::fmt::time::LocalTime;
 use tracing_subscriber::fmt::{self};
@@ -19,10 +18,13 @@ use tracing::debug;
 use tracing::error;
 
 mod firewall;
+mod ssh;
 mod sftp;
 
 // Janky hack to address https://github.com/tokio-rs/tracing/issues/1817
 struct NewType(Pretty);
+
+pub(crate) const SSH_LISTEN_PORT: u16 = 22;
 
 impl<'writer> FormatFields<'writer> for NewType {
     fn format_fields<R: RecordFields>(
@@ -75,9 +77,9 @@ async fn main() {
         }
     }
 
-    debug!("starting sftp server");
+    debug!("starting ssh server");
 
-    if let Err(e) = crate::sftp::start_sftp_server().await {
+    if let Err(e) = crate::ssh::start_ssh_server(SSH_LISTEN_PORT).await {
         error!("{}", e);
     }
 }

--- a/crates/daemon/src/sftp.rs
+++ b/crates/daemon/src/sftp.rs
@@ -1,10 +1,7 @@
 use std::collections::HashMap;
 use std::io::SeekFrom;
-use std::net::SocketAddr;
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::Context;
 use russh_sftp::protocol::Stat;
@@ -13,13 +10,6 @@ use tokio::io::AsyncReadExt;
 use tokio::io::AsyncSeek;
 
 use async_trait::async_trait;
-use russh::server::Auth;
-use russh::server::Msg;
-use russh::server::Server as _;
-use russh::server::Session;
-use russh::Channel;
-use russh::ChannelId;
-use russh_keys::key::KeyPair;
 use russh_sftp::protocol::Attrs;
 use russh_sftp::protocol::File;
 use russh_sftp::protocol::FileAttributes;
@@ -38,87 +28,6 @@ use tracing::debug;
 use tracing::error;
 use tracing::info;
 
-#[derive(Clone)]
-struct Server;
-
-impl russh::server::Server for Server {
-    type Handler = SshSession;
-
-    fn new_client(&mut self, _: Option<SocketAddr>) -> Self::Handler {
-        SshSession::default()
-    }
-}
-
-struct SshSession {
-    clients: Arc<Mutex<HashMap<ChannelId, Channel<Msg>>>>,
-}
-
-impl Default for SshSession {
-    fn default() -> Self {
-        Self {
-            clients: Arc::new(Mutex::new(HashMap::new())),
-        }
-    }
-}
-
-impl SshSession {
-    pub async fn get_channel(&mut self, channel_id: ChannelId) -> Channel<Msg> {
-        let mut clients = self.clients.lock().await;
-        clients.remove(&channel_id).unwrap()
-    }
-}
-
-#[async_trait]
-impl russh::server::Handler for SshSession {
-    type Error = anyhow::Error;
-
-    async fn auth_password(&mut self, user: &str, password: &str) -> Result<Auth, Self::Error> {
-        info!("credentials: {}, {}", user, password);
-        Ok(Auth::Accept)
-    }
-
-    async fn auth_publickey(
-        &mut self,
-        user: &str,
-        public_key: &russh_keys::key::PublicKey,
-    ) -> Result<Auth, Self::Error> {
-        info!("credentials: {}, {:?}", user, public_key);
-        Ok(Auth::Accept)
-    }
-
-    async fn channel_open_session(
-        &mut self,
-        channel: Channel<Msg>,
-        _session: &mut Session,
-    ) -> Result<bool, Self::Error> {
-        {
-            let mut clients = self.clients.lock().await;
-            clients.insert(channel.id(), channel);
-        }
-        Ok(true)
-    }
-
-    async fn subsystem_request(
-        &mut self,
-        channel_id: ChannelId,
-        name: &str,
-        session: &mut Session,
-    ) -> Result<(), Self::Error> {
-        info!("subsystem: {}", name);
-
-        if name == "sftp" {
-            let channel = self.get_channel(channel_id).await;
-            let sftp = SftpSession::default();
-            session.channel_success(channel_id);
-            russh_sftp::server::run(channel.into_stream(), sftp).await;
-        } else {
-            session.channel_failure(channel_id);
-        }
-
-        Ok(())
-    }
-}
-
 struct InternalHandle {
     path: PathBuf,
     file: Option<tokio::fs::File>,
@@ -131,7 +40,7 @@ impl InternalHandle {
 }
 
 #[derive(Default)]
-struct SftpSession {
+pub(crate) struct SftpSession {
     version: Option<u32>,
     root_dir_read_done: bool,
     handles: HashMap<String, InternalHandle>,
@@ -609,28 +518,4 @@ impl russh_sftp::server::Handler for SftpSession {
         debug!("extended: {id} {request}");
         Err(self.unimplemented())
     }
-}
-
-pub(crate) const SFTP_LISTEN_PORT: u16 = 22;
-
-pub async fn start_sftp_server() -> std::io::Result<()> {
-    debug!("in start_sftp_server");
-
-    let config = russh::server::Config {
-        auth_rejection_time: Duration::from_secs(3),
-        auth_rejection_time_initial: Some(Duration::from_secs(0)),
-        keys: vec![KeyPair::generate_ed25519().unwrap()],
-        ..Default::default()
-    };
-
-    let mut server = Server;
-
-    let host = "0.0.0.0";
-    debug!("about to listen on {host}:{SFTP_LISTEN_PORT}");
-
-    server
-        .run_on_address(Arc::new(config), (host, SFTP_LISTEN_PORT))
-        .await?;
-
-    Ok(())
 }

--- a/crates/daemon/src/ssh.rs
+++ b/crates/daemon/src/ssh.rs
@@ -1,0 +1,121 @@
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use russh::server::Auth;
+use russh::server::Msg;
+use russh::server::Server as _;
+use russh::server::Session;
+use russh::Channel;
+use russh::ChannelId;
+use russh_keys::key::KeyPair;
+use tokio::sync::Mutex;
+use tracing::debug;
+use tracing::info;
+
+use crate::sftp::SftpSession;
+
+#[derive(Clone)]
+struct Server;
+
+impl russh::server::Server for Server {
+    type Handler = SshSession;
+
+    fn new_client(&mut self, _: Option<SocketAddr>) -> Self::Handler {
+        SshSession::default()
+    }
+}
+
+struct SshSession {
+    clients: Arc<Mutex<HashMap<ChannelId, Channel<Msg>>>>,
+}
+
+impl Default for SshSession {
+    fn default() -> Self {
+        Self {
+            clients: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl SshSession {
+    pub async fn get_channel(&mut self, channel_id: ChannelId) -> Channel<Msg> {
+        let mut clients = self.clients.lock().await;
+        clients.remove(&channel_id).unwrap()
+    }
+}
+
+#[async_trait]
+impl russh::server::Handler for SshSession {
+    type Error = anyhow::Error;
+
+    async fn auth_password(&mut self, user: &str, password: &str) -> Result<Auth, Self::Error> {
+        info!("credentials: {}, {}", user, password);
+        Ok(Auth::Accept)
+    }
+
+    async fn auth_publickey(
+        &mut self,
+        user: &str,
+        public_key: &russh_keys::key::PublicKey,
+    ) -> Result<Auth, Self::Error> {
+        info!("credentials: {}, {:?}", user, public_key);
+        Ok(Auth::Accept)
+    }
+
+    async fn channel_open_session(
+        &mut self,
+        channel: Channel<Msg>,
+        _session: &mut Session,
+    ) -> Result<bool, Self::Error> {
+        {
+            let mut clients = self.clients.lock().await;
+            clients.insert(channel.id(), channel);
+        }
+        Ok(true)
+    }
+
+    async fn subsystem_request(
+        &mut self,
+        channel_id: ChannelId,
+        name: &str,
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        info!("subsystem: {}", name);
+
+        if name == "sftp" {
+            let channel = self.get_channel(channel_id).await;
+            let sftp = SftpSession::default();
+            session.channel_success(channel_id);
+            russh_sftp::server::run(channel.into_stream(), sftp).await;
+        } else {
+            session.channel_failure(channel_id);
+        }
+
+        Ok(())
+    }
+}
+
+pub async fn start_ssh_server(port: u16) -> std::io::Result<()> {
+    debug!("in start_ssh_server");
+
+    let config = russh::server::Config {
+        auth_rejection_time: Duration::from_secs(3),
+        auth_rejection_time_initial: Some(Duration::from_secs(0)),
+        keys: vec![KeyPair::generate_ed25519().unwrap()],
+        ..Default::default()
+    };
+
+    let mut server = Server;
+
+    let host = "0.0.0.0";
+    debug!("about to listen on {host}:{port}");
+
+    server
+        .run_on_address(Arc::new(config), (host, port))
+        .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Seemed cleaner to separate these two modules in the beginning, before starting to work on the SSH PTY implementation.