### PR TITLE
fix(ci): Distinct feature enabling only for component: daemon

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         component: [shellcode_utils, loader, shellcode_stage1, shellcode_stage1_network, shellcode_stage2, shellcode_gen, daemon, server]
+        include:
+          - component: daemon
+            features: firewall
 
     steps:
       - name: Checkout
@@ -22,7 +25,7 @@ jobs:
 
       - name: Build ${{ matrix.component }}
         working-directory: crates/${{ matrix.component }}
-        run: cargo build --release --all-features
+        run: cargo build --release --features=${{ matrix.features }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
As discussed `--all-features` also enables unwanted debugging-features for release builds, hence enabling only a specific feature-flag for `daemon` compnent.