### PR TITLE
feat(daemon): Implement authorized_keys parsing

### DIFF
--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -28,6 +28,8 @@ windows = { version = "0.58.0", features = [
     "Win32_NetworkManagement_WindowsFilteringPlatform",
     "Win32_System_Rpc",
 ] }
+
+[target.'cfg(windows)'.dependencies]
 winreg = "0.52"
 
 [features]


### PR DESCRIPTION
Additional to the authorized-keys feature the dependency "winreg" was guarded with `[target.'cfg(windows)'.dependencies]`.