### PR TITLE
fix(daemon): SFTP overwriting behaviour

### DIFF
--- a/crates/solstice_daemon/src/sftp.rs
+++ b/crates/solstice_daemon/src/sftp.rs
@@ -144,14 +144,6 @@ async fn set_file_attributes(file: &mut tokio::fs::File, target_attrs: &FileAttr
         }
     }
 
-    let mut current_permissions = metadata.permissions();
-    if current_permissions.readonly() != target_attrs.permissions().is_readonly() {
-        debug!("Toggling read-only attribute for file {file:?}");
-        current_permissions.set_readonly(target_attrs.permissions().is_readonly());
-        file.set_permissions(current_permissions)
-            .await?;
-    }
-
     Ok(())
 }
 

--- a/crates/solstice_daemon/src/sftp.rs
+++ b/crates/solstice_daemon/src/sftp.rs
@@ -431,7 +431,7 @@ impl russh_sftp::server::Handler for SftpSession {
                     .await
                     .context("writing file")
                 {
-                    Ok(_) => Err(StatusCode::Ok),
+                    Ok(_) => Ok(self.success(id)),
                     Err(e) => {
                         error!("{:?}", e);
                         Err(StatusCode::Failure)
@@ -600,7 +600,7 @@ impl russh_sftp::server::Handler for SftpSession {
         &mut self,
         id: u32,
         path: String,
-        attrs: FileAttributes,
+        _attrs: FileAttributes,
     ) -> Result<Status, Self::Error> {
         debug!("mkdir: {id} {path}");
         if let Some(path) = unix_like_path_to_windows_path(&path) {
@@ -803,7 +803,7 @@ impl russh_sftp::server::Handler for SftpSession {
         request: String,
         data: Vec<u8>,
     ) -> Result<russh_sftp::protocol::Packet, Self::Error> {
-        debug!("extended: {id} {request}");
+        debug!("extended: {id} {request} {data:?}");
         Err(self.unimplemented())
     }
 }


### PR DESCRIPTION
The way how scp does file overwrites:

```
stat: 1 /D/overwrite
unix to windows path: /D/overwrite
returning translated path: "D:\\overwrite"
open: 2 /D/overwrite OpenFlags(10) FileAttributes { size: None, uid: None, user: None, gid: None, group: None, permissions: Some(420), atime: None, mtime: None }
unix to windows path: /D/overwrite
returning translated path: "D:\\overwrite"

~~ Do file write ~~

fsetstat: 3 /D/overwrite FileAttributes { size: Some(5), uid: None, user: None, gid: None, group: None, permissions: None, atime: None, mtime: None }
close: 4 /D/overwrite
```

aka.

- stat file
- open file with flags: (WRITE | CREATE)
- write to the non-truncated file handle
- fsetstat, setting the filesize, hence truncating it
- close file handle

Since our implementation of fsetstat looked like this

```rs
    fn set_file_attributes(&self, path: &PathBuf, attrs: &FileAttributes) {
        // TODO: Implement me
    }
```

well, you see the problem...

This PR implements `set_file_attributes`, only caring about forcing filesize tho, as unix's chmod / chown does not make much sense for a Windows filesystem.

`set_dir_attributes`-stub was also added, in case this is needed at some point.