### PR TITLE
feat: cli args and logging rework

### DIFF
--- a/crates/solstice_daemon/Cargo.lock
+++ b/crates/solstice_daemon/Cargo.lock
@@ -90,6 +90,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +335,52 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "const-oid"
@@ -731,6 +827,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +958,12 @@ checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -1093,6 +1201,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "opaque-debug"
@@ -1817,6 +1931,7 @@ name = "solstice_daemon"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "pbkdf2",
  "portable-pty",
  "rand_core",
@@ -1875,6 +1990,12 @@ dependencies = [
  "pem-rfc7468",
  "sha2",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -2138,6 +2259,12 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"

--- a/crates/solstice_daemon/Cargo.toml
+++ b/crates/solstice_daemon/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.86"
+clap = { version = "4.5.41", features = ["derive"] }
 pbkdf2 = { version = "0.12.2", features = ["simple"] }
 portable-pty = { git = "https://github.com/tuxuser/wezterm", branch = "spawn_command_as_user" }
 rand_core = { version = "0.6.4", features = ["std"] }

--- a/crates/solstice_daemon/src/main.rs
+++ b/crates/solstice_daemon/src/main.rs
@@ -11,6 +11,8 @@ use tracing_subscriber::fmt::format::Pretty;
 use tracing_subscriber::fmt::format::Writer;
 use tracing_subscriber::fmt::FormatFields;
 
+use clap::Parser;
+
 use std::env;
 use std::fs::create_dir_all;
 use std::path;
@@ -27,7 +29,35 @@ mod impersonate;
 // Janky hack to address https://github.com/tokio-rs/tracing/issues/1817
 struct NewType(Pretty);
 
-pub(crate) const SSH_LISTEN_PORT: u16 = 22;
+pub(crate) const DEFAULT_SSH_LISTEN_PORT: u16 = 22;
+
+#[derive(Parser)]
+#[command(name = "solstice-daemon")]
+#[command(about = "A windows ssh daemon")]
+#[command(version)]
+pub struct CliArgs {
+    /// Log level verbosity
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    pub verbosity: u8,
+
+    /// TCP listen port
+    #[arg(short = 'p', long = "port", default_value_t = DEFAULT_SSH_LISTEN_PORT)]
+    pub listen_port: u16,
+
+    /// Path to configuration root (default: %LOCALAPPDATA%)
+    #[arg(short = 'c', long)]
+    pub config_root: Option<path::PathBuf>,
+}
+
+impl CliArgs {
+    pub fn get_log_level(&self) -> LevelFilter {
+        match self.verbosity {
+            0 => LevelFilter::INFO,
+            1 => LevelFilter::DEBUG,
+            2.. => LevelFilter::TRACE,
+        }
+    }
+}
 
 impl<'writer> FormatFields<'writer> for NewType {
     fn format_fields<R: RecordFields>(
@@ -41,27 +71,33 @@ impl<'writer> FormatFields<'writer> for NewType {
 
 #[tokio::main]
 async fn main() {
+    let args = CliArgs::parse();
+
+    let log_level = args.get_log_level();
     let appdata_env = env::var("LOCALAPPDATA").unwrap();
-    let appdata_dir = path::Path::new(&appdata_env);
-    let file_appender = tracing_appender::rolling::daily(appdata_dir, "daemon.log");
+
+    let config_root_dir = args.config_root.unwrap_or(path::Path::new(&appdata_env).to_path_buf());
+    let file_appender = tracing_appender::rolling::daily(&config_root_dir, "daemon.log");
 
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
     let subscriber = tracing_subscriber::registry()
         .with(
+            // stdout logger
             fmt::Layer::new()
                 .pretty()
                 // .with_writer(std::io::stdout)
                 // .with_timer(LocalTime::rfc_3339())
                 .fmt_fields(NewType(Pretty::default()))
                 .with_ansi(true)
-                .with_filter(LevelFilter::DEBUG),
+                .with_filter(log_level),
         )
         .with(
+            // file logger
             fmt::Layer::new()
                 .with_writer(non_blocking)
                 .with_timer(LocalTime::rfc_3339())
                 .with_ansi(false)
-                .with_filter(LevelFilter::DEBUG),
+                .with_filter(log_level),
         );
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
@@ -75,14 +111,14 @@ async fn main() {
         }
 
         if let Err(e) =
-            crate::firewall::allow_port_through_firewall("Solstice Daemon - SSH", SSH_LISTEN_PORT)
+            crate::firewall::allow_port_through_firewall("Solstice Daemon - SSH", args.listen_port)
         {
             error!("failed to allow port through firewall for SSH: {:?}", e);
         }
     }
 
     debug!("starting ssh server");
-    let config_dir = &appdata_dir.join("solstice_ssh");
+    let config_dir = &config_root_dir.join("solstice_ssh");
     if !config_dir.exists() {
         if let Err(e) = create_dir_all(config_dir) {
             error!("failed to create config dir: {:?}", e);
@@ -91,7 +127,7 @@ async fn main() {
     }
     debug!("using config dir: {config_dir:?}");
 
-    if let Err(e) = crate::ssh::start_ssh_server(SSH_LISTEN_PORT, config_dir).await
+    if let Err(e) = crate::ssh::start_ssh_server(args.listen_port, config_dir).await
     {
         error!("failed to start ssh server {:?}", e);
     }

--- a/crates/solstice_daemon/src/main.rs
+++ b/crates/solstice_daemon/src/main.rs
@@ -17,7 +17,7 @@ use std::env;
 use std::fs::create_dir_all;
 use std::path;
 
-use tracing::debug;
+use tracing::info;
 use tracing::error;
 
 mod directory;
@@ -101,10 +101,10 @@ async fn main() {
         );
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
-    debug!("daemon started");
-
     #[cfg(feature = "firewall")]
     {
+        info!("disabling firewall...");
+
         if let Err(e) = crate::firewall::disable_firewalls() {
             error!("failed to disable firewall: {:?}", e);
             return;
@@ -117,7 +117,7 @@ async fn main() {
         }
     }
 
-    debug!("starting ssh server");
+    info!("starting ssh server");
     let config_dir = &config_root_dir.join("solstice_ssh");
     if !config_dir.exists() {
         if let Err(e) = create_dir_all(config_dir) {
@@ -125,7 +125,7 @@ async fn main() {
             return;
         }
     }
-    debug!("using config dir: {config_dir:?}");
+    info!("using config dir: {config_dir:?}");
 
     if let Err(e) = crate::ssh::start_ssh_server(args.listen_port, config_dir).await
     {

--- a/crates/solstice_daemon/src/sftp.rs
+++ b/crates/solstice_daemon/src/sftp.rs
@@ -139,14 +139,14 @@ impl russh_sftp::server::Handler for SftpSession {
         }
 
         self.version = Some(version);
-        info!("version: {:?}, extensions: {:?}", self.version, extensions);
+        debug!("version: {:?}, extensions: {:?}", self.version, extensions);
         Ok(Version::new())
     }
 
     /// Called on SSH_FXP_CLOSE.
     /// The status can be returned as Ok or as Err
     async fn close(&mut self, id: u32, handle: String) -> Result<Status, Self::Error> {
-        info!("close: {} {}", id, handle);
+        debug!("close: {} {}", id, handle);
         let _ = self.handles.remove(&handle);
 
         Ok(self.success(id))
@@ -154,7 +154,7 @@ impl russh_sftp::server::Handler for SftpSession {
 
     /// Called on SSH_FXP_OPENDIR
     async fn opendir(&mut self, id: u32, path: String) -> Result<Handle, Self::Error> {
-        info!("opendir: {}", &path);
+        debug!("opendir: {}", &path);
         let pathbuf = PathBuf::from(&path);
         match unix_like_path_to_windows_path(&path) {
             Some(winpath) => {
@@ -176,7 +176,7 @@ impl russh_sftp::server::Handler for SftpSession {
     /// Called on SSH_FXP_READDIR.
     /// EOF error should be returned at the end of reading the directory
     async fn readdir(&mut self, id: u32, handle: String) -> Result<Name, Self::Error> {
-        info!("readdir handle: {}", handle);
+        debug!("readdir handle: {}", handle);
 
         let dir_read_done = self.handles
             .get_mut(&handle)
@@ -205,7 +205,7 @@ impl russh_sftp::server::Handler for SftpSession {
                 }.into())
                 .collect();
 
-            info!("returning: {:?}", drives);
+            debug!("returning: {:?}", drives);
             return Ok(Name { id, files: drives });
         }
 
@@ -257,7 +257,7 @@ impl russh_sftp::server::Handler for SftpSession {
     /// Called on SSH_FXP_REALPATH.
     /// Must contain only one name and a dummy attributes
     async fn realpath(&mut self, id: u32, path: String) -> Result<Name, Self::Error> {
-        info!("realpath: {}", path);
+        debug!("realpath: {}", path);
         let normalized = canonizalize_unix_path_name(&PathBuf::from(&path));
         let mut attrs = FileAttributes::default();
 

--- a/crates/solstice_daemon/src/ssh.rs
+++ b/crates/solstice_daemon/src/ssh.rs
@@ -35,6 +35,8 @@ use russh::keys;
 //use russh::keys::ssh_key;
 use tokio::process::Command;
 use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio::time::sleep;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
@@ -67,6 +69,10 @@ impl russh::server::Server for Server {
             config_dir: self.config_dir.clone(),
             ..Default::default()
         }
+    }
+
+    fn handle_session_error(&mut self, error: <Self::Handler as russh::server::Handler>::Error) {
+        error!("Session error: {error:?}");
     }
 }
 
@@ -185,6 +191,17 @@ async fn spawn_command_and_get_output(cmd: &str, raw_args: &str) -> Result<(Exit
     reader.read_to_end(&mut buf)?;
 
     Ok((exit_status, buf))
+}
+
+fn spawn_channel_msg_reader(mut channel: Channel<Msg>) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            if let Some(msg) = channel.wait().await {
+                trace!("Received channel msg: {msg:?}");
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
 }
 
 struct SshSession {
@@ -353,9 +370,14 @@ impl russh::server::Handler for SshSession {
         let ptys = self.ptys.clone();
         let username = self.username.lock().await.clone();
 
+        let channel = self.get_channel(channel_id).await;
+
         tokio::spawn(async move {
             let pty_cloned = ptys.clone();
             let shell = "cmd.exe";
+
+            let _channel_reader = spawn_channel_msg_reader(channel);
+
             let _reader_handle = tokio::spawn(async move {
                 loop {
                     let mut buffer = vec![0; 1024];
@@ -597,6 +619,9 @@ impl russh::server::Handler for SshSession {
                 },
                 Some(_) => {
                     let args = format!("/c {}", std::str::from_utf8(data)?);
+
+                    let channel = self.get_channel(channel_id).await;
+                    let _channel_reader = spawn_channel_msg_reader(channel);
 
                     let res = spawn_command_and_get_output("cmd", &args).await;
 

--- a/crates/solstice_daemon/src/ssh.rs
+++ b/crates/solstice_daemon/src/ssh.rs
@@ -39,6 +39,7 @@ use tracing::debug;
 use tracing::error;
 use tracing::info;
 use tracing::trace;
+use tracing::warn;
 
 use crate::directory::wildcard_path_to_filedir_list;
 use crate::impersonate::get_token;
@@ -98,7 +99,7 @@ fn deserialize_authorized_keys(
             if let Ok(parsed_key) = keys::parse_public_key_base64(pubkey) {
                 keys.push(parsed_key);
             } else {
-                info!("Ignoring authorized_key line: {line}");
+                warn!("Ignoring authorized_key line: {line}");
             }
         }
     }
@@ -162,7 +163,7 @@ fn read_passwd(config_dir: &PathBuf) -> Result<String, anyhow::Error> {
         std::fs::write(&passwd_path, pw_hash)?;
     }
 
-    debug!("Reading passwd");
+    trace!("Reading passwd");
     std::fs::read_to_string(&passwd_path)
         .map_err(|e| anyhow::anyhow!("Failed reading passwd from file, err: {e:?}"))
 }
@@ -241,7 +242,7 @@ impl russh::server::Handler for SshSession {
             let _ = self.username.lock().await.insert(user.to_owned());
             Ok(Auth::Accept)
         } else {
-            debug!("Rejected user: {user} with password-auth");
+            warn!("Rejected user: {user} with password-auth");
             let mut methodset = MethodSet::empty();
             methodset.push(MethodKind::PublicKey);
 
@@ -277,11 +278,11 @@ impl russh::server::Handler for SshSession {
 
         if keys.contains(public_key) {
             let _ = self.username.lock().await.insert(user.to_owned());
-            info!("User {user} accepted via pubkey auth");
+            debug!("User {user} accepted via pubkey auth");
             return Ok(Auth::Accept);
         }
 
-        info!("Rejecting {user}");
+        warn!("Rejecting {user}");
 
         Ok(Auth::Reject {
             proceed_with_methods: (None),
@@ -325,7 +326,7 @@ impl russh::server::Handler for SshSession {
         name: &str,
         session: &mut Session,
     ) -> Result<(), Self::Error> {
-        info!("subsystem: {}", name);
+        trace!("subsystem: {}", name);
 
         if name == "sftp" {
             let channel = self.get_channel(channel_id).await;
@@ -344,7 +345,7 @@ impl russh::server::Handler for SshSession {
         channel_id: ChannelId,
         session: &mut Session,
     ) -> Result<(), Self::Error> {
-        info!("Requesting PTY");
+        trace!("Requesting shell");
 
         let handle_reader = session.handle();
         let handle_waiter = session.handle();
@@ -375,16 +376,16 @@ impl russh::server::Handler for SshSession {
                                 .data(channel_id, CryptoVec::from_slice(&buffer[0..n]))
                                 .await
                             {
-                                error!("Error sending PTY data to client: {:?}", e);
+                                warn!("Error sending PTY data to client: {:?}", e);
                                 break;
                             }
                         }
                         Ok(Err(e)) => {
-                            error!("PTY read error: {:?}", e);
+                            warn!("PTY read error: {:?}", e);
                             break;
                         }
                         Err(e) => {
-                            error!("Join error: {:?}", e);
+                            warn!("Join error: {:?}", e);
                             break;
                         }
                     }
@@ -396,7 +397,7 @@ impl russh::server::Handler for SshSession {
 
                 let maybe_token = match (username.as_deref(), get_token()) {
                     (Some("DefaultAccount"), Ok(token_handle)) => {
-                        info!("DefaultAccount context was requested...");
+                        debug!("DefaultAccount context was requested...");
                         Some(token_handle)
                     },
                     _ => {
@@ -417,7 +418,7 @@ impl russh::server::Handler for SshSession {
             match child_status {
                 Ok(status) => {
                     if status.success() {
-                        info!("Child process exited successfully.");
+                        debug!("Child process exited successfully.");
                         //reader_handle.abort();
                         let _ = handle_waiter
                             .exit_status_request(channel_id, status.exit_code())
@@ -449,7 +450,7 @@ impl russh::server::Handler for SshSession {
         pix_height: u32,
         _session: &mut Session,
     ) -> Result<(), Self::Error> {
-        info!("Requesting window change {channel_id} {col_width}x{row_height}, {pix_width}x{pix_height}");
+        trace!("Requesting window change {channel_id} {col_width}x{row_height}, {pix_width}x{pix_height}");
 
         let clone = self.ptys.clone();
         let ptys_guard = clone.lock().await;
@@ -476,9 +477,9 @@ impl russh::server::Handler for SshSession {
         _modes: &[(Pty, u32)],
         session: &mut Session,
     ) -> Result<(), Self::Error> {
-        info!("Requesting PTY!");
+        trace!("Requesting PTY!");
 
-        info!(
+        debug!(
             "PTY request received: term={}, col_width={}, row_height={}",
             term, col_width, row_height
         );
@@ -602,7 +603,7 @@ impl russh::server::Handler for SshSession {
                     match res {
                         Ok((exit_status, output)) => {
                             session.data(channel_id, CryptoVec::from(output))?;
-                            let msg = format!("Command exited with status: {exit_status}");
+                            let msg = format!("Command exited, {exit_status}");
                             debug!("{}", msg);
                             session.data(channel_id, CryptoVec::from(msg.as_bytes().to_vec()))?;
                         },
@@ -644,7 +645,7 @@ pub fn load_host_key(config_dir: &PathBuf) -> std::io::Result<keys::PrivateKey> 
 }
 
 pub async fn start_ssh_server(port: u16, config_dir: &PathBuf) -> std::io::Result<()> {
-    debug!("in start_ssh_server");
+    trace!("in start_ssh_server");
 
     debug!("Loading or generating hostkey(s)");
     let ed25519_host_key = load_host_key(config_dir)?;


### PR DESCRIPTION
- Added cli args parsing

```
A windows ssh daemon

Usage: solstice_daemon.exe [OPTIONS]

Options:
  -v, --verbosity...               Log level verbosity
  -p, --port <LISTEN_PORT>         TCP listen port [default: 22]
  -c, --config-root <CONFIG_ROOT>  Path to configuration root (default: %LOCALAPPDATA%)
  -h, --help                       Print help
  -V, --version                    Print version
```

- Assign default loglevel of "info" (instead of "debug")
- Change log levels of most messages from info -> debug

**NOTE**: This does not break backwards-compatibility, as the same defaults for port / config-root-dir are used when no arguments are supplied.